### PR TITLE
Dev

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -3,6 +3,9 @@ from fastapi.middleware.cors import CORSMiddleware
 import whisper
 import torch
 import os
+import ffmpeg
+import numpy as np
+from io import BytesIO
 
 app = FastAPI()
 
@@ -16,94 +19,74 @@ app.add_middleware(
 
 # Global variable for the model directory
 WHISPER_MODELS_DIR = "/app/whisper_models"
-
-# Check if GPU is available
 device = "cuda" if torch.cuda.is_available() else "cpu"
 
 def get_available_models() -> list:
     """Returns the list of available Whisper models (as .pt files) in the directory."""
     try:
-        # List all items in the WHISPER_MODELS_DIR
         all_items = os.listdir(WHISPER_MODELS_DIR)
-        print(f"All items in the model directory: {all_items}")
-
-        # Filter the list to include only .pt files (which are the model files)
-        models = []
-        for item in all_items:
-            if item.endswith('.pt'):
-                model_name = item.replace('.pt', '')  # Remove the .pt extension to get the model name
-                models.append(model_name)
-
-        print(f"Found models: {models}")
+        models = [item.replace('.pt', '') for item in all_items if item.endswith('.pt')]
         return models
     except Exception as e:
         print(f"Error while fetching models: {e}")
         return []
 
-def load_model(model_name: str):
-    """Load the model dynamically from the specified directory."""
+def load_audio_from_memory(audio_bytes: BytesIO) -> np.ndarray:
+    """Loads audio from BytesIO into a NumPy array using ffmpeg."""
     try:
-        model_path = os.path.join(WHISPER_MODELS_DIR, model_name) + ".pt"
-        if os.path.exists(model_path):
-            model = whisper.load_model(model_name, download_root=WHISPER_MODELS_DIR).to(device)
-            return model
-        else:
-            raise ValueError(f"Model {model_name} not found in {WHISPER_MODELS_DIR}.")
+        audio_bytes.seek(0)  # Rewind the file-like object to the beginning
+        if audio_bytes.getbuffer().nbytes == 0:
+            raise ValueError("Uploaded file is empty.")
+        
+        process = (
+            ffmpeg.input('pipe:0')
+            .output('pipe:1', format='wav', acodec='pcm_s16le', ac=1, ar='16000')
+            .run_async(pipe_stdin=True, pipe_stdout=True, pipe_stderr=True)
+        )
+
+        out, err = process.communicate(input=audio_bytes.read())
+        if process.returncode != 0:
+            print(f"FFmpeg error: {err}")
+            raise HTTPException(status_code=500, detail="Error decoding audio with ffmpeg.")
+
+        # Ensure correct conversion to np.int16 to match the 16-bit PCM audio format
+        audio_data = np.frombuffer(out, dtype=np.int16).astype(np.float32) / 32768.0
+        return audio_data
     except Exception as e:
-        print(f"Error while loading model: {e}")
-        raise HTTPException(status_code=500, detail=f"Error loading model {model_name}: {str(e)}")
-
-def save_file(file: UploadFile) -> str:
-    """Save the uploaded file to the local system."""
-    ext = file.filename.split('.')[-1]
-    filename = f"temp.{ext}"
-    with open(filename, "wb") as f:
-        f.write(file.file.read())
-    return filename
-
-def extract_audio(video_file: str) -> str:
-    """Extract audio from a video file using ffmpeg."""
-    audio_file = "audio.wav"
-    if not video_file.endswith(('.mp4', '.mkv', '.avi')):
-        raise RuntimeError(f"Invalid file type for audio extraction: {video_file}")
-    command = f"ffmpeg -i {video_file} -vn -acodec pcm_s16le -ar 44100 -ac 2 {audio_file}"
-    os.system(command)
-    return audio_file
-
-def detect_language(audio_file: str, model) -> str:
-    """Detect the language of the audio using the Whisper model."""
-    result = model.transcribe(audio_file, language=None, task="detect-language")
-    return result['language']
+        print(f"Error decoding audio: {e}")
+        raise HTTPException(status_code=500, detail=f"Error decoding audio: {e}")
 
 @app.get("/models/")
 async def list_models():
     """List the available models in the whisper_models directory."""
-    models = get_available_models()
-    return {"models": models}
+    return {"models": get_available_models()}
 
 @app.post("/transcribe/")
 async def transcribe(
     file: UploadFile = File(...),
-    selected_model: str = Form("base"),  # Changed from model_name to selected_model
+    whisper_model_name: str = Form("base"),
     language: str = Form(None)
 ):
-    """Transcribe an audio or video file."""
+    """Transcribe an audio or video file with auto language detection if no language is provided."""
     try:
         # Load the model dynamically
-        model = load_model(selected_model)  # Using selected_model here
-        filename = save_file(file)
-        
-        # If it's a video, extract the audio
-        if filename.endswith(('.mp4', '.mkv', '.avi')):
-            audio_file = extract_audio(filename)
-        else:
-            audio_file = filename
-        
-        # Detect the language if not provided
-        if not language:
-            language = detect_language(audio_file, model)
+        model = whisper.load_model(whisper_model_name, download_root=WHISPER_MODELS_DIR).to(device)
 
-        result = model.transcribe(audio_file, language=language)
+        # Read the uploaded file into memory
+        file_bytes = await file.read()
+        if not file_bytes:
+            raise HTTPException(status_code=400, detail="Uploaded file is empty or corrupt.")
+        
+        audio_file = BytesIO(file_bytes)
+
+        # Load the audio into a NumPy array
+        audio_data = load_audio_from_memory(audio_file)
+
+        # If language is None or empty, don't pass the language, let Whisper auto-detect
+        transcribe_options = {"language": language} if language else {}
+
+        # Transcribe the audio
+        result = model.transcribe(audio_data, **transcribe_options)
 
         # Include timestamps in the transcription
         segments = result['segments']
@@ -111,11 +94,9 @@ async def transcribe(
             {"text": segment['text'], "start": segment['start'], "end": segment['end']}
             for segment in segments
         ]
-
-        os.remove(filename)
-        os.remove(audio_file)
+         
         return {
-            "detected_language": language,
+            "detected_language": result["language"],
             "transcription": transcription_with_timestamps
         }
     except Exception as e:
@@ -125,39 +106,38 @@ async def transcribe(
 @app.post("/translate/")
 async def translate(
     file: UploadFile = File(...),
-    selected_model: str = Form("base"),  # Changed from model_name to selected_model
+    whisper_model_name: str = Form("base"),
     source_language: str = Form(None),
     target_language: str = Form("en")
 ):
-    """Translate an audio or video file."""
+    """Translate an audio or video file with auto language detection if no source language is provided."""
     try:
-        # Load the model dynamically
-        model = load_model(selected_model)  # Using selected_model here
-        filename = save_file(file)
+        model = whisper.load_model(whisper_model_name, download_root=WHISPER_MODELS_DIR).to(device)
 
-        # If it's a video, extract the audio
-        if filename.endswith(('.mp4', '.mkv', '.avi')):
-            audio_file = extract_audio(filename)
-        else:
-            audio_file = filename
+        # Read the uploaded file into memory
+        file_bytes = await file.read()
+        if not file_bytes:
+            raise HTTPException(status_code=400, detail="Uploaded file is empty or corrupt.")
+        
+        audio_file = BytesIO(file_bytes)
 
-        # Detect the source language if not provided
-        if not source_language:
-            source_language = detect_language(audio_file, model)
+        # Load the audio into a NumPy array
+        audio_data = load_audio_from_memory(audio_file)
 
-        result = model.transcribe(audio_file, task="translate", language=source_language)
+        # If source_language is None or empty, don't pass the language, let Whisper auto-detect
+        transcribe_options = {"task": "translate", "language": source_language} if source_language else {"task": ">
 
-        # Include timestamps in the translation
+        # Perform translation
+        result = model.transcribe(audio_data, **transcribe_options)
+        
         segments = result['segments']
         translation_with_timestamps = [
             {"text": segment['text'], "start": segment['start'], "end": segment['end']}
             for segment in segments
         ]
-
-        os.remove(filename)
-        os.remove(audio_file)
+         
         return {
-            "detected_language": source_language,
+            "detected_language": result["language"],
             "translation": translation_with_timestamps
         }
     except Exception as e:

--- a/backend/main.py
+++ b/backend/main.py
@@ -94,7 +94,7 @@ async def transcribe(
             {"text": segment['text'], "start": segment['start'], "end": segment['end']}
             for segment in segments
         ]
-         
+        
         return {
             "detected_language": result["language"],
             "transcription": transcription_with_timestamps
@@ -125,7 +125,7 @@ async def translate(
         audio_data = load_audio_from_memory(audio_file)
 
         # If source_language is None or empty, don't pass the language, let Whisper auto-detect
-        transcribe_options = {"task": "translate", "language": source_language} if source_language else {"task": ">
+        transcribe_options = {"task": "translate", "language": source_language} if source_language else {"task": "translate"}
 
         # Perform translation
         result = model.transcribe(audio_data, **transcribe_options)
@@ -135,7 +135,7 @@ async def translate(
             {"text": segment['text'], "start": segment['start'], "end": segment['end']}
             for segment in segments
         ]
-         
+        
         return {
             "detected_language": result["language"],
             "translation": translation_with_timestamps

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 openai-whisper
 python-multipart
+ffmpeg-python


### PR DESCRIPTION
## Description

This pull request introduces changes that improve the handling of auto language detection in both the transcription and translation functionalities. When an empty string or `None` is provided for the language field, the system now allows Whisper to automatically detect the language without explicitly requiring the user to specify it.

This resolves the issue where auto language detection wasn't triggered when an empty string was provided for the language parameter.

## Related Issue

Closes # [6]
Closes # [9]

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

The changes have been tested by uploading various audio files with different languages and testing both the transcription and translation functionalities:
- [x] Test A: Transcription with an empty language string to confirm Whisper auto-detects the language.
- [x] Test B: Translation with an empty source language string to confirm Whisper auto-detects the language and translates to the target language.

**Test Configuration**:
* Firmware version: N/A
* Hardware: N/A
* Toolchain: N/A
* SDK: N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules